### PR TITLE
Fix run example failed

### DIFF
--- a/split-example/run-example.sh
+++ b/split-example/run-example.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+mkdir build
 node ../index.js --platform android --output build --config .splitconfig --dev true
 
-mkdirs android/app/src/main/assets/bundle
+mkdir android/app/src/main/assets/bundle
 rm -rf android/app/src/main/assets/bundle/*
 cp -R build/bundle-output/split/* android/app/src/main/assets/bundle
 cd android


### PR DESCRIPTION
Fix 运行run-example.sh脚本时因为缺少build目录而导致的失败