### PR TITLE
add the split bundle methode when the platform is ios

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -122,7 +122,7 @@ class Parser {
       if (subBundle.assetRenames) {
         subBundle.assetRenames.forEach(item => {
           const assetNewDir = path.dirname(item.newPath);
-          Util.ensureFolder(assetNewDir);
+          Util.mkdirsSync(assetNewDir);
           console.log('[Resource] Move resource ' + item.originPath + ' to ' + item.newPath);
           fs.createReadStream(item.originPath).pipe(fs.createWriteStream(item.newPath));
         });
@@ -351,9 +351,28 @@ class Parser {
           });
         }
       )
+    } else {
+      console.log('Get ios asset renames', asset);
+      asset.scales.forEach(scale => {
+        const relativePath = this._getAssetDestPathIOS(asset, scale);
+        const originPath = path.resolve(this._config.bundleDir, relativePath);
+        if(Util.ensureFolder(originPath)) {
+          assetRenames.push({
+            originPath,
+            relativePath: relativePath,
+            newPath: path.resolve(this._config.outputDir, bundle, relativePath)
+          });
+        }
+      });
     }
     
     return assetRenames;
+  }
+
+  _getAssetDestPathIOS(asset, scale) {
+    const suffix = scale === 1 ? '' : '@' + scale + 'x';
+    const fileName = asset.name + suffix + '.' + asset.type;
+    return path.join(asset.httpServerLocation.substr(1), fileName);
   }
   
   _doSplit() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -197,6 +197,21 @@ export function ensureFolder(dir : string) {
   }
 }
 
+/**
+ * 递归创建目录 同步方法
+ */
+export function mkdirsSync(dirname) {  
+    //console.log(dirname);  
+    if (fs.existsSync(dirname)) {  
+        return true;  
+    } else {  
+        if (mkdirsSync(path.dirname(dirname))) {  
+            fs.mkdirSync(dirname);  
+            return true;  
+        }  
+    }  
+}
+
 // export function resolvePathArrays(root: string, array : Array<any>, val ?: string) : Array<any> {
 //   const newArr = [];
 //   array.forEach(item => {


### PR DESCRIPTION
自行阅读并运行了代码，发现代码只有在android的情况下能对bundle拆包，ios情况下的资源文件没进行相关拆包处理。
修改的地方有：
1、parser.js  125行，原方法没办法递归新建目录
2、parser.js 356行，添加 platform = ios 情况的资源文件处理

测试：
改变run-example.sh 中 --platform andriod 改为 --platform ios不生效，需要将index.js中platform的默认值改为ios才能生效。修改后运行，测试可以生效