### PR TITLE
修复ReactRootView.attachToReactInstanceManager被重复调用的问题

### DIFF
--- a/split-example/android/app/src/main/java/com/example/BaseSubBundleActivity.java
+++ b/split-example/android/app/src/main/java/com/example/BaseSubBundleActivity.java
@@ -34,6 +34,7 @@ public abstract class BaseSubBundleActivity extends Activity {
         @Override
         protected void onPostExecute(Void aVoid) {
             getReactNativeHost().getReactInstanceManager().attachMeasuredRootView(mReactRootView);
+            Utils.setViewAttached(mReactRootView, true);
         }
 
     }

--- a/split-example/android/app/src/main/java/com/example/Utils.java
+++ b/split-example/android/app/src/main/java/com/example/Utils.java
@@ -67,6 +67,18 @@ class Utils {
         }
     }
 
+    public static void setViewAttached(ReactRootView rootView, boolean bAttached) {
+        try {
+            Field field = ReactRootView.class.getDeclaredField("mIsAttachedToInstance");
+            field.setAccessible(true);
+            field.set(rootView, bAttached);
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
     @Nullable
     static CatalystInstance getCatalystInstance(ReactNativeHost host) {
         ReactInstanceManager manager = host.getReactInstanceManager();


### PR DESCRIPTION
如果不设置mIsAttachedToInstance为true，那么ReactRootView在onMeasure时会重复调用一次attachToReactInstanceManager()